### PR TITLE
Updated docs to include installation dependencies

### DIFF
--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -8,19 +8,22 @@ own copies of the following files (from the Midway ROM set):
 
   pacman.6e pacman.6f pacman.6h pacman.6j
 
-Copy them to the same directory as this file, then run make.bat (Windows).
-Under Mac/Linux/Un*x, use make to build the final pacemuzx.tap image file,
-or combine manually using:
+Copy them to the same directory as this file, then perform the following steps:
 
-  cat start.part pacman.6[efhj] end.part > pacemuzx.tap
+* Install https://github.com/simonowen/tile2sam (e.g. in a python3 virtual environment)
+* Build/install https://github.com/mkoloberdin/pasmo
+* Run `make.bat` (Windows) or `make dist` (Mac/Linux/Un*x)
+* Mac/Linux/Un*x: Copy/move the `pacman.6*` ROM files into the generated `dist` directory,
+  `cd dist` and run `make` to generate `pacemuzx.tap`
 
-Then load the .tap tape image in a Spectrum emulator of your choosing.
+Then load the .tap tape image in a Spectrum emulator of your choosing (making sure
+to select a Spectrum +2A/+2B/+3 model, as noted above).
 
 Controls:
 
   1 = 1 player start
   2 = 2 player start
-  3 = insert coin
+  3 = insert coin (NOTE: you need to do this first, once per player!)
 
   C = colour sprites
   M = mono sprites


### PR DESCRIPTION
Hey Simon, I think this should fix #1. I didn't test on Windows, only on Mac.

I think the top level Makefile requires the pacman6.* files to exist, and then separately, the `dist` subdirectory with the second `Makefile` also requires them, which is why I added the step to move them to the `dist` dir after running the top level `Makefile`.

No worries if you don't like my wording, I'm happy for you to close the PR and word things differently, I just wanted to share with you the steps I needed to perform, and figured a PR was the most constructive way.

By the way, I love it, it is an awesome emulator!